### PR TITLE
[SATS-090] - [BE] Implement Admin Login Functionality

### DIFF
--- a/api/database/seeders/AdminSeeder.php
+++ b/api/database/seeders/AdminSeeder.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\EmployeeStatusEnum;
+use App\Enums\RoleEnum;
+use App\Models\User;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class AdminSeeder extends Seeder
+{
+  /**
+   * Run the database seeds.
+   *
+   * @return void
+   */
+  public function run()
+  {
+    User::upsert([
+      'id_number' => '19-10323',
+      'name' => 'Charline Miro',
+      'email' => 'charlinemiro01@gmail.com',
+      'password' => bcrypt('sweetbadass'),
+      'birth_date' => '2001/10/21',
+      'contact_number' => '09518335791',
+      'is_verified' => true,
+      'employee_status_id' => EmployeeStatusEnum::EMPLOYED->value,
+      'role_id' => RoleEnum::ADMIN->value
+    ], ['id']);
+  }
+}

--- a/api/database/seeders/DatabaseSeeder.php
+++ b/api/database/seeders/DatabaseSeeder.php
@@ -17,6 +17,7 @@ class DatabaseSeeder extends Seeder
     $this->call([
       RoleSeeder::class,
       EmployeeStatusSeeder::class,
+      AdminSeeder::class,
     ]);
   }
 }


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203127372768065/1203127372768090/f

## Definition of Done
- [x] Created a seeder for the default admin account

## Notes
- Admin will have only 1 account in the system

## Pre-condition
- Run the command `php artisan db:seed` to apply the seeder

## Expected Output
- Admin's account will be created and stored in the database

## Screenshots/Recordings
- Seeded Data

![image](https://user-images.githubusercontent.com/108660012/194742411-1d4b9c18-0d4c-478c-b53e-b70c25fe4b9f.png)
