### PR TITLE
[SATS-089-1] - [Markup] Create Admin Login Page

### DIFF
--- a/client/src/components/molecules/AuthForm/index.tsx
+++ b/client/src/components/molecules/AuthForm/index.tsx
@@ -11,6 +11,7 @@ import { SignInFormSchema, SignUpFormSchema } from '~/shared/validation'
 import { AxiosResponseError, SignInUpFormValues } from '~/shared/types'
 
 type Props = {
+  type?: string | 'alumni'
   isLogin?: boolean | false
   actions: {
     handleAuthSubmit: (data: SignInUpFormValues) => Promise<void>
@@ -25,6 +26,7 @@ const AuthForm: FC<Props> = (props): JSX.Element => {
   const [showPass, setShowPass] = useState(false)
 
   const {
+    type,
     isLogin,
     actions: { handleAuthSubmit },
     axiosErrors: { isError, error }
@@ -48,7 +50,7 @@ const AuthForm: FC<Props> = (props): JSX.Element => {
   return (
     <form onSubmit={handleSubmit(handleAuthSubmit)}>
       <div className="grid gap-x-6 gap-y-2.5">
-        {!isLogin && (
+        {!isLogin && type && (
           <>
             <div className="col-span-12">
               <label htmlFor="id-number" className="block text-sm font-medium">
@@ -104,7 +106,7 @@ const AuthForm: FC<Props> = (props): JSX.Element => {
           </>
         )}
         <div className="col-span-12">
-          <label htmlFor="email-address" className="block text-sm font-medium">
+          <label htmlFor="email-address" className="block text-sm font-medium text-white">
             <small className="text-rose-600">*</small> Email address
           </label>
           <input
@@ -123,7 +125,7 @@ const AuthForm: FC<Props> = (props): JSX.Element => {
           />
           {errors?.email && <span className="error">{`${errors?.email?.message}`}</span>}
         </div>
-        {!isLogin && (
+        {!isLogin && type && (
           <>
             <div className="col-span-12">
               <label className="block text-sm font-medium">
@@ -198,7 +200,7 @@ const AuthForm: FC<Props> = (props): JSX.Element => {
           </>
         )}
         <div className="col-span-12">
-          <label htmlFor="password" className="block text-sm font-medium">
+          <label htmlFor="password" className="block text-sm font-medium text-white">
             <small className="text-rose-600">*</small> Password
           </label>
           <div className="relative">
@@ -242,7 +244,7 @@ const AuthForm: FC<Props> = (props): JSX.Element => {
           </div>
           {errors?.password && <span className="error">{`${errors?.password?.message}`}</span>}
         </div>
-        {!isLogin && (
+        {!isLogin && type && (
           <div className="col-span-12">
             <label htmlFor="confirm-password" className="block text-sm font-medium">
               <small className="text-rose-600">*</small> Confirm Password
@@ -266,7 +268,7 @@ const AuthForm: FC<Props> = (props): JSX.Element => {
             )}
           </div>
         )}
-        {isLogin && (
+        {isLogin && !type && (
           <div className="col-span-12 flex w-full items-center">
             <div className="mt-2 flex items-center">
               <div className="flex h-5 items-center">
@@ -284,7 +286,7 @@ const AuthForm: FC<Props> = (props): JSX.Element => {
           </div>
         )}
       </div>
-      <div className={`text-right ${isLogin ? 'mt-16' : 'mt-8'}`}>
+      <div className={`text-right ${isLogin && type === 'alumni' ? 'mt-16' : 'mt-8'}`}>
         <button
           type="submit"
           disabled={isSubmitting}

--- a/client/src/pages/admin/index.tsx
+++ b/client/src/pages/admin/index.tsx
@@ -19,34 +19,28 @@ const Admin: NextPage = (): JSX.Element => {
   return (
     <>
       <Head>
-        <title>Alumni Tracking System | Admin</title>
+        <title>Admin Login</title>
+        <meta name="description" content="404 Page Not Found" />
       </Head>
-      <section className="flex h-screen justify-center bg-white">
-        <div className="relative hidden w-2/3 bg-[url('/images/bg-slsu3.jpg')] bg-cover lg:block">
-          <div className="absolute inset-0 bg-black/10"></div>
-          <div className="flex h-screen items-center px-20">
-            <div className="space-y-2">
-              <h2 className="rounded border bg-white/30 p-0.5 text-5xl font-bold text-white drop-shadow-lg">
-                Alumni Tracking System
-              </h2>
-              <p className="mt-3 max-w-xl text-xl text-white drop-shadow-md">
-                Warning: Unauthorized Personnel are Strictly Prohibited
-              </p>
-            </div>
+      <main
+        className="flex h-screen min-h-screen items-center justify-center px-4"
+        style={{
+          background: `linear-gradient(180deg, #083C76 17.22%, rgba(8, 60, 118, 0) 99.97%), #4497EE`
+        }}
+      >
+        <div className="w-full max-w-sm space-y-10">
+          <div className="flex flex-shrink-0 flex-col items-center space-y-6">
+            <img src="/images/logo.png" className="h-24 w-24" alt="" />
+            <h1 className="text-3xl font-bold text-white">Admin Login</h1>
           </div>
+          <AuthForm
+            isLogin
+            type="admin"
+            actions={{ handleAuthSubmit }}
+            axiosErrors={{ isError, error }}
+          />
         </div>
-        <div className="mx-auto flex w-full max-w-md items-center px-6 lg:w-2/6">
-          <div className="flex-1">
-            <div className="text-center">
-              <h2 className="text-center text-4xl font-bold text-gray-700">Administrator</h2>
-              <p className="mt-3 text-gray-500">only authorized personnel are allowed</p>
-            </div>
-            <div className="mt-8">
-              <AuthForm isLogin actions={{ handleAuthSubmit }} axiosErrors={{ isError, error }} />
-            </div>
-          </div>
-        </div>
-      </section>
+      </main>
     </>
   )
 }

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -15,7 +15,12 @@ const Login: NextPage = (): JSX.Element => {
 
   return (
     <AuthLayout metaTitle="Login">
-      <AuthForm isLogin actions={{ handleAuthSubmit }} axiosErrors={{ isError, error }} />
+      <AuthForm
+        isLogin
+        actions={{ handleAuthSubmit }}
+        type="alumni"
+        axiosErrors={{ isError, error }}
+      />
     </AuthLayout>
   )
 }

--- a/client/src/pages/register.tsx
+++ b/client/src/pages/register.tsx
@@ -16,7 +16,7 @@ const Register: NextPage = (): JSX.Element => {
 
   return (
     <AuthLayout metaTitle="Registration">
-      <AuthForm actions={{ handleAuthSubmit }} axiosErrors={{ isError, error }} />
+      <AuthForm actions={{ handleAuthSubmit }} type="alumni" axiosErrors={{ isError, error }} />
     </AuthLayout>
   )
 }


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203127372768065/1203214569765511/f

## Definition of Done
- [x] Recreate admin login with reusable AuthForm component

## Notes
- https://www.figma.com/file/Qo1E20gG9NQBdnYU5j4qG3/SATS?node-id=517%3A128

## Pre-condition
- Go to admin route login

## Expected Output
- It will display the newly created admin login page

## Screenshots/Recordings
![image](https://user-images.githubusercontent.com/108642414/197372676-9dacc70f-bd91-4a72-b1a7-7e26dde2462e.png)