### PR TITLE
[SATS-526] - [FE] Integrate Set On/Off SMS Messaging Functionality

### DIFF
--- a/api/app/Http/Controllers/AdminSettingController.php
+++ b/api/app/Http/Controllers/AdminSettingController.php
@@ -7,6 +7,12 @@ use Illuminate\Http\Request;
 
 class AdminSettingController extends Controller
 {
+  public function index()
+  {
+    $setting = AdminSetting::firstOrFail();
+    return response()->json($setting->status);
+  }
+
   public function store(Request $request)
   {
     $setting = AdminSetting::firstOrFail();

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -22,6 +22,7 @@ Route::group(['middleware' => 'auth:sanctum'], function () {
   Route::get('auth', [AuthController::class, 'index']);
 
   Route::put('user/change-password', [UpdatePasswordController::class, 'update']);
+  Route::get('admin/sms-status', [AdminSettingController::class, 'index']);
   Route::post('admin/change-sms-setting', [AdminSettingController::class, 'store']);
   Route::apiResource('user', UserController::class)->only(['index', 'store', 'destroy']);
   Route::apiResource('post', PostController::class)->except(['show']);

--- a/client/src/components/atoms/SwitchToggle/index.tsx
+++ b/client/src/components/atoms/SwitchToggle/index.tsx
@@ -1,12 +1,12 @@
-import { useState } from 'react'
-import { Switch } from '@headlessui/react'
+import { useState } from 'react';
+import { Switch } from '@headlessui/react';
 
 type Props = {
   value: (value: boolean) => void;
   className?: string;
   isDisabled?: boolean;
-  state: boolean
-}
+  state: any
+};
 
 const SwitchToggle: React.FC<Props> = ({ value, className, isDisabled, state }) => {
   const [enabled, setEnabled] = useState(state);
@@ -16,7 +16,7 @@ const SwitchToggle: React.FC<Props> = ({ value, className, isDisabled, state }) 
 
     setEnabled(!enabled);
     value(!enabled);
-  }
+  };
 
   return (
     <div className={className}>
@@ -33,6 +33,6 @@ const SwitchToggle: React.FC<Props> = ({ value, className, isDisabled, state }) 
         />
       </Switch>
     </div>
-  )
-}
+  );
+};
 export default SwitchToggle;

--- a/client/src/components/molecules/AdminSettings/index.tsx
+++ b/client/src/components/molecules/AdminSettings/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 
 import ModalCard from '~/components/templates/ModalCard';
 import SubmitButton from '~/components/atoms/SubmitButton';
@@ -18,7 +18,13 @@ type Password = {
 };
 
 const AdminSettings = ({ isOpen, setIsOpen }: AdminSettings) => {
-  const { changeAdminPassword, error } = adminHooks();
+  const {
+    error,
+    isSuccess,
+    getSmsStatus,
+    setSmsSetting,
+    changeAdminPassword,
+  } = adminHooks();
   const { content } = error;
   const [active, setActive] = useState<string>("Post");
   const { currentPassword, newConfirmedPassword, newPassword } =
@@ -32,7 +38,14 @@ const AdminSettings = ({ isOpen, setIsOpen }: AdminSettings) => {
     const value = e.currentTarget.innerText;
     setActive(value);
   };
-  
+
+  const [smsStatus, setSmsStatus] = useState<boolean | Promise<any>>(false);
+  useEffect(() => {
+    getSmsStatus().then((res) => {
+      setSmsStatus(res);
+    });
+  }, [isSuccess]);
+
   const menuList = ["Post", "Security"];
   const modalMenu = menuList.map((menu: string, index: number) => {
     return (
@@ -46,14 +59,10 @@ const AdminSettings = ({ isOpen, setIsOpen }: AdminSettings) => {
     );
   });
 
-  const [passwordData, setPasswordData] = useState<Password>({
-    currentPassword: "",
-    newPassword: "",
-    newConfirmedPassword: ""
-  });
-  const onPasswordChange = (e: { target: { value: string, name: string; }; }): void => {
-    const value = e.target.value;
-    const name = e.target.name;
+  const [passwordData, setPasswordData] = useState<Password | null>(null);
+  const onPasswordChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    const { value, name } = e.target;
+
     setPasswordData((prev: any) => ({ ...prev, [name]: value }));
   };
 
@@ -72,6 +81,7 @@ const AdminSettings = ({ isOpen, setIsOpen }: AdminSettings) => {
         break;
 
       case "post":
+        setSmsSetting(value);
         break;
 
       default:
@@ -95,7 +105,7 @@ const AdminSettings = ({ isOpen, setIsOpen }: AdminSettings) => {
                   className="disabled:hover:ring-2 hover:ring-blue-600 focus:ring-2 focus:ring-blue-600 disabled:opacity-50 ring-1 ring-slate_300 transition duration-150 ease-in-out hover:ring-2 block w-full rounded border-none px-3 py-2 text-sm placeholder:text-slate_400 text-slate_900"
                   disabled={false}
                   placeholder="********"
-                  value={passwordData.currentPassword || ""}
+                  value={passwordData?.currentPassword || ""}
                   onChange={onPasswordChange}
                 />
                 {error && <div className="flex flex-col justify-start w-full text-left">
@@ -114,7 +124,7 @@ const AdminSettings = ({ isOpen, setIsOpen }: AdminSettings) => {
                   className="disabled:hover:ring-2 hover:ring-blue-600 focus:ring-2 focus:ring-blue-600 disabled:opacity-50 ring-1 ring-slate_300 transition duration-150 ease-in-out hover:ring-2 block w-full rounded border-none px-3 py-2 text-sm placeholder:text-slate_400 text-slate_900"
                   disabled={false}
                   placeholder="***********"
-                  value={passwordData.newPassword || ""}
+                  value={passwordData?.newPassword || ""}
                   onChange={onPasswordChange}
                 />
                 {error && <span className="text-sm text-red-600 float-left text-left">{newPassword}</span>}
@@ -129,7 +139,7 @@ const AdminSettings = ({ isOpen, setIsOpen }: AdminSettings) => {
                   className="disabled:hover:ring-2 hover:ring-blue-600 focus:ring-2 focus:ring-blue-600 disabled:opacity-50 ring-1 ring-slate_300 transition duration-150 ease-in-out hover:ring-2 block w-full rounded border-none px-3 py-2 text-sm placeholder:text-slate_400 text-slate_900"
                   disabled={false}
                   placeholder="***********"
-                  value={passwordData.newConfirmedPassword || ""}
+                  value={passwordData?.newConfirmedPassword || ""}
                   onChange={onPasswordChange}
                 />
                 {error && <span className="text-sm text-red-600 float-left text-left">{newConfirmedPassword}</span>}
@@ -154,7 +164,7 @@ const AdminSettings = ({ isOpen, setIsOpen }: AdminSettings) => {
                   <TaskIcon />
                   <p className="text-slate_900 text-[15px] text-left">Automatically send post in SMS</p>
                 </div>
-                <SwitchToggle value={switchState} className="mt-[3px]" state={true} />
+                <SwitchToggle value={switchState} className="mt-[3px]" state={smsStatus} />
               </div>
             </div>
           </div>

--- a/client/src/hooks/admin/adminHooks.ts
+++ b/client/src/hooks/admin/adminHooks.ts
@@ -18,12 +18,11 @@ const adminHooks = () => {
     }
   })
   const { isError, isSuccess, isLoading, error } = fetchStatus
-  const csrf = () => axios.get('/sanctum/csrf-cookie')
 
   const changeAdminPassword = async (data: any) => {
     try {
-      await csrf()
       const response = await axios.put('/api/user/change-password', data)
+      setFetchStatus(setData(fetchStatus, { isLoading: true }))
 
       toast.success('Password reset successfully!')
       setFetchStatus(
@@ -34,11 +33,42 @@ const adminHooks = () => {
           }
         })
       )
-      return response;
-    } catch (err: any) {
-      setFetchStatus(setData(fetchStatus, { error: catchError(err) }))
-      return err?.response
+      return response
+    } catch (err: any) { 
+      return setErrorMessage(err)
     }
+  }
+
+  const getSmsStatus = async () => {
+    try {
+      const response = await axios.get('/api/admin/sms-status')
+      
+      return response?.data
+    } catch (err: any) {
+      return setErrorMessage(err)
+    }
+  }
+
+  const setSmsSetting = async (status: boolean | undefined) => { 
+    try {
+      const response = await axios.post('/api/admin/change-sms-setting')
+
+      toast.success(`Automatic post to SMS turned ${status ? 'on' : 'off'}!`)
+      setFetchStatus(setData(fetchStatus, { isSuccess: true }))
+
+      return response
+    } catch (err: any) {
+      return setErrorMessage(err)
+    }
+  }
+
+  const setErrorMessage = (err: any) => {
+    toast.error('Something went wrong, please try again later.')
+
+    setFetchStatus(setData(fetchStatus, { isError: true }))
+    setFetchStatus(setData(fetchStatus, { error: catchError(err) }))
+
+    return err?.response
   }
 
   return {
@@ -47,6 +77,8 @@ const adminHooks = () => {
     isSuccess,
     isLoading,
     fetchStatus,
+    getSmsStatus,
+    setSmsSetting,
     changeAdminPassword
   }
 }


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203127372768065/1203260764965526/f

## Definition of Done
- [ ] Admin can turn on the automatic post to SMS message
- [ ] Admin can turn off the automatic post to SMS message

## Pre-condition
- Go to settings and click the toggle option

## Expected Output
- When the settings for the automatic post to SMS are on, the user will receive an SMS notification every post
- If the settings for the automatic post to SMS are off, the user will not receive an SMS notification

## Screenshots/Recordings
![image](https://user-images.githubusercontent.com/104751512/200619573-d84417fb-a4fd-43f9-92c6-63dd958d3abc.png)
![image](https://user-images.githubusercontent.com/104751512/200619586-23e1dc39-db97-48d3-9600-d1b050479320.png)
