### PR TITLE
[SATS-530] - [FE] Fetch and Display Alumni's and Posts in User Newsfeed Page

### DIFF
--- a/api/app/Http/Controllers/AlumniController.php
+++ b/api/app/Http/Controllers/AlumniController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\Request;
+use App\Http\Resources\UserResource;
+
+class AlumniController extends Controller
+{
+
+    public function __invoke()
+    {
+        return UserResource::collection(
+            User::with('avatar', 'batch')
+                ->applicants()
+                ->approved()
+                ->get()
+        );
+    }
+}

--- a/api/app/Http/Controllers/PostController.php
+++ b/api/app/Http/Controllers/PostController.php
@@ -16,7 +16,7 @@ class PostController extends Controller
     public function store(PostRequest $request)
     {
         $post = new Post();
-        return $post->createPost($request);;
+        return $post->createPost($request);
     }
 
     public function update(PostRequest $request, Post $post)

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\AdminSettingController;
+use App\Http\Controllers\AlumniController;
 use App\Http\Controllers\Auth\AuthController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\PostController;
@@ -36,7 +37,8 @@ Route::group(['middleware' => 'auth:sanctum'], function () {
         Route::delete('user-avatar', [UserAvatarController::class, 'destroy']);
         Route::put('/', UpdateUserController::class);
     });
-    
+
     Route::apiResource('user', UserController::class)->except(['show', 'update']);
     Route::apiResource('post', PostController::class)->except(['show']);
+    Route::get('alumni', AlumniController::class);
 });

--- a/client/next.config.js
+++ b/client/next.config.js
@@ -1,12 +1,10 @@
 /** @type {import('next').NextConfig} */
 module.exports = {
   reactStrictMode: true,
+  env: {
+    NEXT_PUBLIC_BACKEND_URL: process.env.NEXT_PUBLIC_BACKEND_URL
+  },
   images: {
     domains: ['media.istockphoto.com', 'ca.slack-edge.com']
-  },
-  env: {
-    NEXT_PUBLIC_BACKEND_URL: process.env.NEXT_PUBLIC_BACKEND_URL,
-    NEXT_PUBLIC_PUSHER_KEY: process.env.NEXT_PUBLIC_PUSHER_KEY,
-    NEXT_PUBLIC_PUSHER_CLUSTER: process.env.NEXT_PUBLIC_PUSHER_CLUSTER
   }
 }

--- a/client/src/components/atoms/Skeletons/NewsFeedPostSkeleton.tsx
+++ b/client/src/components/atoms/Skeletons/NewsFeedPostSkeleton.tsx
@@ -1,0 +1,43 @@
+import React, { FC } from 'react'
+
+const NewsFeedPostSkeleton: FC = (): JSX.Element => {
+  return (
+    <>
+      {[0, 1, 2, 3, 4].map((i) => (
+        <div
+          key={i}
+          role="status"
+          className="w-fulll mx-auto mt-5 max-w-xl animate-pulse rounded-md border border-gray-200 px-6 py-4 shadow"
+        >
+          <div className="mb-4 flex items-center space-x-3">
+            <svg
+              className="h-14 w-14 shrink-0 text-gray-200"
+              aria-hidden="true"
+              fill="currentColor"
+              viewBox="0 0 20 20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                fillRule="evenodd"
+                d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-6-3a2 2 0 11-4 0 2 2 0 014 0zm-2 4a5 5 0 00-4.546 2.916A5.986 5.986 0 0010 16a5.986 5.986 0 004.546-2.084A5 5 0 0010 11z"
+                clipRule="evenodd"
+              ></path>
+            </svg>
+            <div>
+              <div className="mb-2 h-2.5 w-32 rounded-full bg-gray-200"></div>
+              <div className="h-2 w-48 rounded-full bg-gray-200"></div>
+            </div>
+          </div>
+          <div className="mb-4 h-2.5 w-48 rounded-full bg-gray-200"></div>
+          <div className="mb-2.5 h-2 rounded-full bg-gray-200"></div>
+          <div className="mb-2.5 h-2 rounded-full bg-gray-200"></div>
+          <div className="h-2 rounded-full bg-gray-200"></div>
+
+          <span className="sr-only">Loading...</span>
+        </div>
+      ))}
+    </>
+  )
+}
+
+export default NewsFeedPostSkeleton

--- a/client/src/components/atoms/Skeletons/ProfileCardSkeleton.tsx
+++ b/client/src/components/atoms/Skeletons/ProfileCardSkeleton.tsx
@@ -1,0 +1,42 @@
+import React, { FC } from 'react'
+
+const ProfileCardSkeleton: FC = (): JSX.Element => {
+  return (
+    <div className="sticky top-[86px] hidden h-[330px] w-full max-w-[280px] overflow-hidden rounded-lg border bg-white md:block">
+      <div role="status" className="max-w-sm animate-pulse">
+        <div className="mb-4 flex h-48 items-center justify-center bg-gray-300">
+          <svg
+            className="h-12 w-12 text-gray-200"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+            fill="currentColor"
+            viewBox="0 0 640 512"
+          >
+            <path d="M480 80C480 35.82 515.8 0 560 0C604.2 0 640 35.82 640 80C640 124.2 604.2 160 560 160C515.8 160 480 124.2 480 80zM0 456.1C0 445.6 2.964 435.3 8.551 426.4L225.3 81.01C231.9 70.42 243.5 64 256 64C268.5 64 280.1 70.42 286.8 81.01L412.7 281.7L460.9 202.7C464.1 196.1 472.2 192 480 192C487.8 192 495 196.1 499.1 202.7L631.1 419.1C636.9 428.6 640 439.7 640 450.9C640 484.6 612.6 512 578.9 512H55.91C25.03 512 .0006 486.1 .0006 456.1L0 456.1z" />
+          </svg>
+        </div>
+        <div className="-mt-20 flex flex-col items-center justify-center space-x-3">
+          <svg
+            className="h-[110px] w-[110px] text-gray-200"
+            aria-hidden="true"
+            fill="currentColor"
+            viewBox="0 0 20 20"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              fillRule="evenodd"
+              d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-6-3a2 2 0 11-4 0 2 2 0 014 0zm-2 4a5 5 0 00-4.546 2.916A5.986 5.986 0 0010 16a5.986 5.986 0 004.546-2.084A5 5 0 0010 11z"
+              clipRule="evenodd"
+            ></path>
+          </svg>
+          <div className="mt-4 space-y-3">
+            <div className="h-2.5 w-32 rounded-full bg-gray-200"></div>
+            <div className="h-2 w-48 rounded-full bg-gray-200"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ProfileCardSkeleton

--- a/client/src/components/templates/AdminLayout/index.tsx
+++ b/client/src/components/templates/AdminLayout/index.tsx
@@ -41,7 +41,7 @@ const AdminLayout: FC<Props> = ({ metaTitle, children }): JSX.Element => {
         <div className="relative h-full min-h-screen overflow-y-auto bg-white">
           <main
             className={`mx-auto min-h-[80vh] max-w-6xl p-5 pl-4 ${
-              isOpenSidebar ? 'pl-0 md:pl-60' : ''
+              isOpenSidebar ? 'pl-4 md:pl-60' : ''
             }`}
           >
             {children}

--- a/client/src/components/templates/AlumniLayout/index.tsx
+++ b/client/src/components/templates/AlumniLayout/index.tsx
@@ -1,11 +1,13 @@
 import Head from 'next/head'
 import userHooks from '~/hooks/user/userHooks'
+import alumniHooks from '~/hooks/user/alumniHooks'
 import React, { FC, useState, ReactNode } from 'react'
 
-import { alumniData } from '~/shared/data/alumniData'
+import useAlumni from '~/hooks/user/alumniHooks'
 import handleImageError from '~/utils/handleImageError'
 import AlumniHeader from '~/components/organisms/AlumniHeader'
 import AlumniSettings from '~/components/molecules/AlumniSettings'
+import ProfileCardSkeleton from '~/components/atoms/Skeletons/ProfileCardSkeleton'
 
 type Props = {
   children: ReactNode
@@ -14,6 +16,7 @@ type Props = {
 
 const AlumniLayout: FC<Props> = ({ metaTitle, children }): JSX.Element => {
   const { data: alumni, error } = userHooks()
+  const { alumniDataList } = useAlumni()
   const [isOpen, setIsOpen] = useState<boolean>(false)
 
   const toggle = (): void => setIsOpen(!isOpen)
@@ -29,40 +32,46 @@ const AlumniLayout: FC<Props> = ({ metaTitle, children }): JSX.Element => {
 
       <main className="mx-auto flex max-w-[90rem] pt-[60px] md:space-x-10 md:px-4">
         {/* The Profile Side */}
-        <aside className="sticky top-[86px] hidden h-[330px] w-full max-w-[280px] overflow-hidden rounded-lg bg-white shadow md:block">
-          <section className="h-[130px] overflow-hidden">
-            <img src="/images/bg-slsu3.jpg" className="bg-contain" alt="" />
-          </section>
-          <section className="flex flex-col items-center">
-            <header className="flex items-center justify-center">
-              <div className="-mt-12 flex-shrink-0 overflow-hidden">
-                <img
-                  src={alumni?.avatar[0]?.original_url}
-                  onError={(e) => handleImageError(e, '/images/avatar.png')}
-                  className="h-[110px] w-[110px] rounded-full shadow"
-                  alt=""
-                />
-              </div>
-            </header>
-            <main className="text-center">
-              <h1 className="text-normal mt-4 text-xl line-clamp-1">{alumni?.name}</h1>
-              <p className="text-xs line-clamp-1">{alumni?.email}</p>
-            </main>
-          </section>
-          <section className="relative mt-8 flex flex-col px-4 ">
-            <hr />
-            <button
-              onClick={toggle}
-              className="pt-2 text-center text-sm text-[#083c76] active:scale-95"
-            >
-              My Profile
-            </button>
-            {isOpen && <AlumniSettings isOpen={isOpen} toggle={toggle} />}
-          </section>
-        </aside>
+        {!alumni ? (
+          <ProfileCardSkeleton />
+        ) : (
+          <aside className="sticky top-[86px] hidden h-[330px] w-full max-w-[280px] overflow-hidden rounded-lg bg-white shadow md:block">
+            <section className="h-[130px] overflow-hidden">
+              <img src="/images/bg-slsu3.jpg" className="bg-contain" alt="" />
+            </section>
+            <section className="flex flex-col items-center">
+              <header className="flex items-center justify-center">
+                <div className="-mt-12 flex-shrink-0 overflow-hidden">
+                  <img
+                    src={alumni?.avatar[0].original_url}
+                    className="h-[110px] w-[110px] rounded-full shadow"
+                    onError={(e) => handleImageError(e, '/images/avatar.png')}
+                    alt=""
+                  />
+                </div>
+              </header>
+              <main className="text-center">
+                <h1 className="text-normal mt-4 text-xl line-clamp-1">{alumni?.name}</h1>
+                <p className="text-xs line-clamp-1">{alumni?.email}</p>
+              </main>
+            </section>
+            <section className="relative mt-8 flex flex-col px-4 ">
+              <hr />
+              <button
+                onClick={toggle}
+                className="pt-2 text-center text-sm text-[#083c76] active:scale-95"
+              >
+                My Profile
+              </button>
+              <AlumniSettings isOpen={isOpen} toggle={toggle} />
+            </section>
+          </aside>
+        )}
 
         {/* The Main Content for Admin Post */}
-        <section className="w-full flex-1 bg-white bg-none px-4">{children}</section>
+        <section className="min-h-screen w-full flex-1 bg-white bg-none px-4 pb-14">
+          {children}
+        </section>
 
         {/* The Alumni List */}
         <aside className="sticky top-[86px] hidden h-[86vh] w-full max-w-[300px] overflow-hidden rounded-lg bg-white py-2 shadow lg:block">
@@ -71,15 +80,41 @@ const AlumniLayout: FC<Props> = ({ metaTitle, children }): JSX.Element => {
           </header>
           <nav className="-mt-4 h-full min-h-full w-full overflow-y-auto px-5 py-6 scrollbar-thin scrollbar-thumb-slate-400 scrollbar-thumb-rounded-md">
             <ul className="divide-y divide-slate-200">
-              {alumniData.map((alumni) => (
-                <li key={alumni.id} className="flex items-center space-x-3 py-2.5">
-                  <img src="/images/animated-avatar.jpg" className="h-9 w-9 rounded-full" alt="" />
-                  <div className="flex flex-col">
-                    <h3 className="text-sm font-normal text-gray-900">{alumni.name}</h3>
-                    <p className="text-xs font-light text-gray-500">{alumni.batch}</p>
-                  </div>
-                </li>
-              ))}
+              {alumniDataList ? (
+                alumniDataList?.map((alumni) => (
+                  <li key={alumni.id} className="flex items-center space-x-3 py-2.5">
+                    <img src={alumni.avatar.url} className="h-9 w-9 rounded-full" alt="" />
+                    <div className="flex flex-col">
+                      <h3 className="text-sm font-normal text-gray-900">{alumni.name}</h3>
+                      <p className="text-xs font-light text-gray-500">{alumni?.batch.name}</p>
+                    </div>
+                  </li>
+                ))
+              ) : (
+                <>
+                  {[0, 1, 2, 3, 4, 5, 6].map((i) => (
+                    <div key={i} className="mt-4 flex animate-pulse items-center space-x-3">
+                      <svg
+                        className="h-10 w-10 text-gray-200"
+                        aria-hidden="true"
+                        fill="currentColor"
+                        viewBox="0 0 20 20"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          fillRule="evenodd"
+                          d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-6-3a2 2 0 11-4 0 2 2 0 014 0zm-2 4a5 5 0 00-4.546 2.916A5.986 5.986 0 0010 16a5.986 5.986 0 004.546-2.084A5 5 0 0010 11z"
+                          clipRule="evenodd"
+                        ></path>
+                      </svg>
+                      <div>
+                        <div className="mb-2 h-2.5 w-32 rounded-full bg-gray-200"></div>
+                        <div className="h-2 w-48 rounded-full bg-gray-200"></div>
+                      </div>
+                    </div>
+                  ))}
+                </>
+              )}
             </ul>
           </nav>
         </aside>

--- a/client/src/hooks/admin/adminHooks.ts
+++ b/client/src/hooks/admin/adminHooks.ts
@@ -1,5 +1,7 @@
+import useSWR from 'swr'
 import { useState } from 'react'
 import toast from 'react-hot-toast'
+import { AxiosResponse } from 'axios'
 import { deleteCookie } from 'cookies-next'
 
 import axios from '~/shared/lib/axios'
@@ -156,7 +158,7 @@ const adminHooks = () => {
   const logout = async () => {
     try {
       await axios.post('/logout')
-      
+
       deleteCookie('XSRF-TOKEN')
 
       toast.success('Logout successfully!')

--- a/client/src/hooks/user/alumniHooks.ts
+++ b/client/src/hooks/user/alumniHooks.ts
@@ -1,0 +1,44 @@
+import useSWR from 'swr'
+import { useState } from 'react'
+import toast from 'react-hot-toast'
+import { AxiosResponse } from 'axios'
+import { deleteCookie } from 'cookies-next'
+
+import axios from '~/shared/lib/axios'
+import redirect from '~/utils/redirect'
+import { IAlumniList } from '~/shared/interfaces'
+import { AxiosResponseError } from '~/shared/types'
+import { catchError } from '~/utils/handleAxiosError'
+
+const useAlumni = () => {
+  const [error, setError] = useState<AxiosResponseError>({
+    status: 0,
+    content: null
+  })
+
+  const { data: alumniDataList, mutate } = useSWR(
+    '/api/alumni',
+    () =>
+      axios
+        .get('/api/alumni')
+        .then((res: AxiosResponse) => res.data as IAlumniList[])
+        .catch((error) => {
+          if (error.response.status !== 409) throw error?.response?.statusText
+          toast.error(error?.response?.statusText)
+        }),
+    {
+      revalidateIfStale: false,
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false
+    }
+  )
+
+  return {
+    alumniDataList,
+    error,
+    mutate,
+    isLoading: !alumniDataList
+  }
+}
+
+export default useAlumni

--- a/client/src/hooks/user/newsFeedHooks.ts
+++ b/client/src/hooks/user/newsFeedHooks.ts
@@ -1,0 +1,30 @@
+import useSWR from 'swr'
+import { AxiosResponse } from 'axios'
+
+import axios from '~/shared/lib/axios'
+import { IPost } from '~/shared/interfaces'
+
+const useNewsFeed = () => {
+  const { data, mutate } = useSWR(
+    '/api/post',
+    () =>
+      axios
+        .get('/api/post')
+        .then((res: AxiosResponse) => res.data as IPost[])
+        .catch((error) => {
+          if (error.response.status !== 409) throw error?.response?.statusText
+        }),
+    {
+      refreshInterval: 1000,
+      revalidateOnMount: true
+    }
+  )
+
+  return {
+    data,
+    mutate,
+    isLoading: !data
+  }
+}
+
+export default useNewsFeed

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -1,8 +1,13 @@
+import moment from 'moment'
 import type { NextPage } from 'next'
 
+import useNewsFeed from '~/hooks/user/newsFeedHooks'
 import AlumniLayout from '~/components/templates/AlumniLayout'
+import NewsFeedPostSkeleton from '~/components/atoms/Skeletons/NewsFeedPostSkeleton'
 
 const Index: NextPage = (): JSX.Element => {
+  const { data, isLoading } = useNewsFeed()
+
   return (
     <AlumniLayout metaTitle="Home">
       <div className="boorder-slate-300 mx-auto mt-6 flex w-full max-w-xl items-center justify-between border-b-2">
@@ -31,30 +36,32 @@ const Index: NextPage = (): JSX.Element => {
           </a>
         </button>
       </div>
-      {[0, 1, 2, 3, 4, 5, 6, 7, 8, 9].map((list) => (
-        <section
-          key={list}
-          className="mx-auto mt-6 w-full max-w-xl rounded-lg border bg-white px-6 py-5 shadow transition duration-150 ease-in-out hover:bg-slate-50 hover:shadow-lg"
-        >
-          <header className="flex items-center space-x-3">
-            <div className="flex-shrink-0">
-              <img src="/images/logo.png" alt="" className="h-8 w-8" />
-            </div>
-            <div className="flex flex-col">
-              <h1 className="text-sm font-bold">SLSU - Admin</h1>
-              <p className="text-xs">2 days ago</p>
-            </div>
-          </header>
-          <main className="mt-3 px-2">
-            Lorem ipsum, dolor sit amet consectetur adipisicing elit. Labore amet placeat corporis
-            cupiditate aperiam, quaerat fugiat quae nam beatae assumenda, reprehenderit quam rem
-            recusandae modi omnis quia at earum debitis.
-          </main>
-        </section>
-      ))}
+      {isLoading ? (
+        <NewsFeedPostSkeleton />
+      ) : (
+        <>
+          {data?.map(({ id, content, created_at }) => (
+            <section
+              key={id}
+              className="mx-auto mt-6 w-full max-w-xl rounded-lg border bg-white px-6 py-5 shadow transition duration-150 ease-in-out hover:bg-slate-50 hover:shadow-lg"
+            >
+              <header className="flex items-center space-x-3">
+                <div className="flex-shrink-0">
+                  <img src="/images/logo.png" alt="" className="h-8 w-8" />
+                </div>
+                <div className="flex flex-col">
+                  <h1 className="text-sm font-bold">SLSU - Admin</h1>
+                  <p className="text-xs">{moment(created_at).fromNow()}</p>
+                </div>
+              </header>
+              <main className="mt-3 px-2">{content}</main>
+            </section>
+          ))}
+        </>
+      )}
     </AlumniLayout>
   )
 }
 
-export { UserSignInOutAuthCheck as getServerSideProps } from '~/utils/getServerSideProps';
+export { UserSignInOutAuthCheck as getServerSideProps } from '~/utils/getServerSideProps'
 export default Index

--- a/client/src/shared/interfaces/index.ts
+++ b/client/src/shared/interfaces/index.ts
@@ -27,7 +27,48 @@ export interface IAlumniData {
   avatar: [
     {
       id: number
+      model_type: string
+      model_id: number
+      uuid: string
+      collection_name: string
+      name: string
+      file_name: string
+      mime_type: string
+      disk: string
+      conversions_disk: string
+      size: number
+      manipulations: [] | null | undefined
+      custom_properties: [] | null | undefined
+      generated_conversions: [] | null | undefined
+      responsive_images: [] | null | undefined
+      order_column: number
+      created_at: string
+      updated_at: string
       original_url: string
+      preview_url: string | null | undefined
     }
   ]
+}
+
+export interface IPost {
+  id: number
+  content: string
+  created_at: string
+}
+
+export interface IAlumniList {
+  id: number
+  id_number: string
+  name: string
+  batch: {
+    id: number
+    name: string
+  }
+  avatar: {
+    fileName: string
+    url: string
+  }
+  is_verified: number
+  email: string
+  number: string
 }

--- a/client/src/utils/handleImageError.ts
+++ b/client/src/utils/handleImageError.ts
@@ -1,4 +1,6 @@
-const handleImageError = (event: React.SyntheticEvent<HTMLImageElement, Event>, image: string) => {
+import { SyntheticEvent } from 'react'
+
+const handleImageError = (event: SyntheticEvent<HTMLImageElement, Event>, image: string): void => {
   event.currentTarget.src = image
   event.currentTarget.onerror = null
 }


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203127372768065/1203260764965530/f

## Definition of Done
- [x] Display Admin Post from verified users
- [x] Added skeleton style loading for the alumni post and profile card
- [x] Used `swr` interval and refresh on mount to automatically refresh the data
- [x] Refactor Admin Side for Manage User to automatically render the data
- [x] Created Controller for fetching the alumni data
## Pre-condition
- Go login to your verified alumni account and you'll see the admin post

## Expected Output
- Alumni should able to see the admin posts

## Screenshots/Recordings

### During Registration
![admin side](https://user-images.githubusercontent.com/108642414/203545783-98e59df7-ab99-46c8-87ad-aaa1b9e0ba97.gif)

### Login Side

![login side](https://user-images.githubusercontent.com/108642414/203546177-678710e3-af97-484d-85e9-865bbb66f134.gif)
