### PR TITLE
[Markup] Create page for the List of Employment

### DIFF
--- a/client/src/pages/admin/employment-status.tsx
+++ b/client/src/pages/admin/employment-status.tsx
@@ -1,0 +1,253 @@
+import Swal from 'sweetalert2'
+import { NextPage } from 'next'
+import React, { useState } from 'react'
+import { Disclosure, Tab } from '@headlessui/react'
+import { ChevronUpIcon, MagnifyingGlassIcon } from '@heroicons/react/20/solid'
+
+import Loader from '~/components/atoms/Loader'
+import handleImageError from '~/utils/handleImageError'
+import AdminLayout from '~/components/templates/AdminLayout'
+
+function classNames(...classes: string[]) {
+  return classes.filter(Boolean).join(' ')
+}
+
+const EmploymentStatus: NextPage = (): JSX.Element => {
+  const allEmployment: any = {
+    employed: [
+      {
+        name: 'John Doe Employed',
+        avatar: '/images/avatar.png',
+        id_number: 1,
+        batch: '1',
+        course: 'BSIT',
+        email: 'email@gmail.com',
+        number: '12312312312',
+        work_place: 'Lorem',
+        company_name: 'Ipsum Dolor',
+        position: 'Sit Amet',
+        employment_id: '/images/avatar.png',
+      },
+      {
+        name: 'Jane Doe Employed',
+        avatar: '/images/avatar.png',
+        id_number: 1,
+        batch: '1',
+        course: 'BSIT',
+        email: 'email@gmail.com',
+        number: '12312312312',
+        work_place: 'Lorem',
+        company_name: 'Ipsum Dolor',
+        position: 'Sit Amet',
+        employment_id: '/images/avatar.png',
+      },
+      {
+        name: 'Joan Doe Employed',
+        avatar: '/images/avatar.png',
+        id_number: 1,
+        batch: '1',
+        course: 'BSIT',
+        email: 'email@gmail.com',
+        number: '12312312312',
+        work_place: 'Lorem',
+        company_name: 'Ipsum Dolor',
+        position: 'Sit Amet',
+        employment_id: '/images/avatar.png',
+      }
+    ],
+    unemployed: [
+      {
+        name: 'John Doe Unemployed',
+        avatar: '/images/avatar.png',
+        id_number: 1,
+        batch: '1',
+        course: 'BSIT',
+        email: 'email@gmail.com',
+        number: '12312312312',
+      },
+      {
+        name: 'John Doe Unemployed',
+        avatar: '/images/avatar.png',
+        id_number: 1,
+        batch: '1',
+        course: 'BSIT',
+        email: 'email@gmail.com',
+        number: '12312312312',
+      }
+    ],
+    self_employed: [
+      {
+        name: 'John Doe Self Employed',
+        avatar: '/images/avatar.png',
+        id_number: 1,
+        batch: '1',
+        course: 'BSIT',
+        email: 'email@gmail.com',
+        number: '12312312312',
+      }
+    ]
+  }
+
+  const [employmentList, setEmploymentList] = useState({
+    Employed: [...allEmployment.employed],
+    Unemployed: [...allEmployment.unemployed],
+    Self_Employed: [...allEmployment.self_employed],
+  })
+  const [searchIn, setSearchIn] = useState<string>("Employed")
+  const [searchInput, setSearchInput] = useState<string>("")
+
+  const searchFunction = (value: string) => {
+    if (value === "") {
+      return setEmploymentList({
+        Employed: [...allEmployment.employed],
+        Unemployed: [...allEmployment.unemployed],
+        Self_Employed: [...allEmployment.self_employed]
+      })
+    }
+
+    let filteredData = allEmployment[searchIn?.toLowerCase()]?.filter((data: any, index: number) => {
+      if (data?.name?.toLowerCase().includes(value.toLowerCase())) {
+        return data
+      }
+    })
+    setEmploymentList((prev: any) => ({ ...prev, [searchIn]: [...filteredData] }))
+  }
+
+  const EmploymentStatusData = (
+    <div className="flex justify-center items-center">
+      <div className='w-[525px]'>
+        <Tab.Group>
+          <Tab.List className="flex space-x-1 rounded-xl bg-sams-10 p-1">
+            {Object.keys(employmentList).map((category) => (
+              <Tab
+                key={category}
+                onClick={() => setSearchIn(category)}
+                className={({ selected }) =>
+                  classNames(
+                    'w-full rounded-lg py-2.5 text-sm font-medium leading-5 text-slate-50',
+                    'ring-white ring-opacity-60 ring-offset-2 ring-offset-sams-10 focus:outline-none focus:ring-2',
+                    selected
+                      ? 'bg-sams-30 shadow'
+                      : 'bg-sams-30 bg-opacity-30 text-white text-opacity-100 hover:bg-opacity-100'
+                  )
+                }
+              >
+                {category}
+              </Tab>
+            ))}
+          </Tab.List>
+          <div className="w-full my-2 flex flex-row gap-3 p-2 border-2 border-slate-900 rounded-lg">
+            <MagnifyingGlassIcon
+              className="h-9 w-9"
+            />
+            <input
+              type="text"
+              className="w-full h-full border-none"
+              placeholder="Search by name"
+              onChange={(e: any) => {
+                const value = e.target.value
+
+                searchFunction(value)
+                setSearchInput(value)
+              }}
+            />
+          </div>
+          <Tab.Panels className="mt-2">
+            {Object.values(employmentList).map((lists, idx) => (
+              <Tab.Panel
+                key={idx}
+                className={classNames(
+                  'rounded-xl bg-slate-200 p-3',
+                  'ring-white ring-opacity-60 ring-offset-2 ring-offset-blue-400 focus:outline-none focus:ring-2'
+                )}
+              >
+                {lists?.length === 0 ? (
+                  <h1 className="text-center text-slate-400">No available data</h1>
+                ) : (
+                  <ul className="flex flex-col gap-2">
+                    {lists.map((list: any, index: number) => {
+                      const { name, avatar, id_number, batch, course, email, number, work_place, company_name, position, employment_id } = list || {};
+                      const tableRows = [
+                        { header: "ID Number", value: id_number ?? "---" },
+                        { header: "Batch", value: batch },
+                        { header: "Course", value: course },
+                        { header: "Email", value: email },
+                        { header: "Contact Number", value: number },
+                        { header: "Work Place", value: work_place },
+                        { header: "Company Name", value: company_name },
+                        { header: "Position", value: position },
+                        { header: "Employment ID", value: employment_id }
+                      ]
+
+                      return (
+                        <Disclosure key={index}>
+                          {({ open }) => (
+                            <>
+                              <Disclosure.Button className="flex items-center w-full justify-between rounded-lg bg-[#2563EB] bg-opacity-30 px-4 py-2 text-left text-sm font-medium text-slate-900 hover:bg-sams-10 hover:text-white focus:outline-none focus-visible:ring focus-visible:ring-slate-900 focus-visible:ring-opacity-75">
+                                <div className="flex gap-3 justify-center items-center">
+                                  <img
+                                    src={avatar}
+                                    onError={(e) => handleImageError(e, '/images/avatar.png')}
+                                    alt="profile"
+                                    className="rounded-full max-w-[36px] max-h-[36px] min-w-[36px] min-h-[36px]"
+                                  />
+                                  <span>{name}</span>
+                                </div>
+                                <div className="flex gap-3">
+                                  <ChevronUpIcon
+                                    className={`${open ? 'rotate-180 transform' : ''} h-9 w-9 `}
+                                  />
+                                </div>
+                              </Disclosure.Button>
+                              <Disclosure.Panel className="px-5 mobile:px-0 pt-4 pb-2 text-sm text-slate-900 flex flex-row justify-between mobile:flex-col mobile:gap-5">
+                                <table className='w-full'>
+                                  <tbody>
+                                    {
+                                      tableRows.map((data: any, index: number) => {
+                                        const { header, value } = data;
+
+                                        return (
+                                          value && (
+                                            <tr key={index}>
+                                              <td className='w-[40%]'>
+                                                <span>{header}</span>
+                                              </td>
+                                              <td className='w-[10%]'>
+                                                <span>:</span>
+                                              </td>
+                                              <td className='flex justify-end items-end !w-full'>
+                                                <span>{value}</span>
+                                              </td>
+                                            </tr>
+                                          )
+                                        )
+                                      })
+                                    }
+                                  </tbody>
+                                </table>
+                              </Disclosure.Panel>
+                            </>
+                          )}
+                        </Disclosure>
+                      )
+                    })}
+                  </ul>
+                )}
+
+              </Tab.Panel>
+            ))}
+          </Tab.Panels>
+        </Tab.Group>
+      </div>
+    </div>
+  )
+
+  return (
+    <AdminLayout metaTitle="Administrator | Employment Status">
+      {!allEmployment ? <Loader /> : EmploymentStatusData}
+    </AdminLayout>
+  )
+}
+
+export { AdminSignInOutAuthCheck as getServerSideProps } from '~/utils/getServerSideProps'
+export default EmploymentStatus

--- a/client/src/pages/admin/manage-user.tsx
+++ b/client/src/pages/admin/manage-user.tsx
@@ -152,7 +152,7 @@ const ManageUser: NextPage = (): JSX.Element => {
                 ) : (
                   <ul className="flex flex-col gap-2">
                     {users?.map((user: any, index: number) => {
-                      const { name, avatar, is_verified, id, batch, email, number } = user
+                      const { name, avatar, is_verified, id, batch, email, number, id_number } = user
 
                       return (
                         <Disclosure key={index}>
@@ -178,7 +178,7 @@ const ManageUser: NextPage = (): JSX.Element => {
                               <Disclosure.Panel className="flex flex-row justify-between px-5 pt-4 pb-2 text-sm text-slate-900 mobile:flex-col mobile:gap-5 mobile:px-0">
                                 <div className="w-full">
                                   {[
-                                    { header: 'ID Number', value: id },
+                                    { header: 'ID Number', value: id_number ?? '---' },
                                     { header: 'Batch', value: batch?.name }
                                   ].map((data: any, index: number) => {
                                     const { header, value } = data
@@ -199,7 +199,7 @@ const ManageUser: NextPage = (): JSX.Element => {
                                     ? null
                                     : [
                                       { header: 'Email', value: email },
-                                      { header: 'Number', value: number }
+                                      { header: 'Contact Number', value: number }
                                     ].map((data: any, index: number) => {
                                       const { header, value } = data
                                       return (

--- a/client/src/shared/data/sidebarLinks.ts
+++ b/client/src/shared/data/sidebarLinks.ts
@@ -1,4 +1,4 @@
-import { Grid, FilePlus, Users } from 'react-feather'
+import { Grid, FilePlus, Users, BarChart2 } from 'react-feather'
 
 import { ISidebar } from './../interfaces'
 
@@ -17,5 +17,10 @@ export const sidebarLinks: ISidebar[] = [
     Icon: Users,
     name: 'Manage User',
     href: '/admin/manage-user'
+  },
+  {
+    Icon: BarChart2,
+    name: 'Employment Status',
+    href: '/admin/employment-status'
   }
 ]

--- a/client/src/utils/getServerSideProps.ts
+++ b/client/src/utils/getServerSideProps.ts
@@ -6,8 +6,9 @@ export const AdminSignInOutAuthCheck = ({ req }: any) => {
   const dashboard = path.includes('dashboard')
   const manageUser = path.includes('manage-user')
   const managePost = path.includes('manage-post')
+  const employmentStatus = path.includes('employment-status')
 
-  if ((dashboard || manageUser || managePost) && !xsrfToken) {
+  if ((dashboard || manageUser || managePost || employmentStatus) && !xsrfToken) {
     return {
       redirect: {
         destination: '/admin',
@@ -22,7 +23,7 @@ export const AdminSignInOutAuthCheck = ({ req }: any) => {
     }
   }
 
-  if ((dashboard || manageUser || managePost) && xsrfToken) {
+  if ((dashboard || manageUser || managePost || employmentStatus) && xsrfToken) {
     return {
       props: {}
     }


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203127372768065/1203629268729075/f

## Definition of Done
- [x] Admin can view the list of Employed alumni
- [x] Admin can view the list of Unemployed alumni
- [x] Admin can view the list of Self-employed alumni
- [x] Admin can filter Alumni Employment status by alumni name

## Pre-condition
- http://localhost:3000/admin/employment-status

## Expected Output
- When the admin clicks the Employment Status menu in the sidebar, the default selected should be Employed
- When the admin clicks the Unemployed button, it should filter all the unemployed alumni
- When the admin clicks the Self-employed button, it should filter all the Self-employed alumni
- When the admin search by name, it should filter the result by the matching name in the input bar
- When there is no matching name when searching, it should display `No Data Available`

## Screenshots/Recordings
![image](https://user-images.githubusercontent.com/104751512/210154826-03e358df-9e3d-41d7-b8e2-5e7f617cc8d8.png)
![image](https://user-images.githubusercontent.com/104751512/210152992-0726d5ac-3436-47ca-b4dc-2071a7ab0f75.png)
![image](https://user-images.githubusercontent.com/104751512/210152997-34398564-d099-43fd-ba04-f6fa4be8c60a.png)
![image](https://user-images.githubusercontent.com/104751512/210153012-9b777e82-4af3-4a36-b2f8-faf138e1202a.png)
