### PR TITLE
[Markup] Add course and employment fields in registration

### DIFF
--- a/.hintrc
+++ b/.hintrc
@@ -8,6 +8,25 @@
       {
         "label": "off"
       }
+    ],
+    "no-inline-styles": "off",
+    "axe/structure": [
+      "default",
+      {
+        "list": "off"
+      }
+    ],
+    "axe/name-role-value": [
+      "default",
+      {
+        "button-name": "off"
+      }
+    ],
+    "axe/parsing": [
+      "default",
+      {
+        "duplicate-id-aria": "off"
+      }
     ]
   }
 }

--- a/client/src/components/molecules/AlumniSettings/index.tsx
+++ b/client/src/components/molecules/AlumniSettings/index.tsx
@@ -1,36 +1,40 @@
-import { X } from 'react-feather'
-import toast from 'react-hot-toast'
-import { useForm } from 'react-hook-form'
-import { yupResolver } from '@hookform/resolvers/yup'
-import React, { ChangeEvent, FC, useState } from 'react'
+import { X } from 'react-feather';
+import toast from 'react-hot-toast';
+import { useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import React, { ChangeEvent, FC, useState } from 'react';
 
-import axios from '~/shared/lib/axios'
-import userHooks from '~/hooks/user/userHooks'
-import { About, Profile, Security } from './types'
-import { Spinner } from '~/shared/icons/SpinnerIcon'
-import handleImageError from '~/utils/handleImageError'
-import DialogBox from '~/components/templates/DialogBox'
-import { AboutFormSchema, ProfileFormSchema, SecurityFormSchema } from '~/shared/validation'
+import axios from '~/shared/lib/axios';
+import userHooks from '~/hooks/user/userHooks';
+import { About, Profile, Security } from './types';
+import { Spinner } from '~/shared/icons/SpinnerIcon';
+import handleImageError from '~/utils/handleImageError';
+import DialogBox from '~/components/templates/DialogBox';
+import { AboutFormSchema, ProfileFormSchema, SecurityFormSchema } from '~/shared/validation';
 
 type Props = {
-  isOpen: boolean
-  toggle: () => void
-}
+  isOpen: boolean;
+  toggle: () => void;
+};
 
-const AlumniSettings: FC<Props> = (props): JSX.Element => {
-  const { isOpen, toggle } = props
-  const [formError, setFormError]: any = useState(null)
-  const [active, setActive] = useState<string>('Profile')
-  const { data: alumni, mutate } = userHooks()
+const AlumniSettings: FC<Props> = (props): JSX.Element =>
+{
+  const { isOpen, toggle } = props;
+  const [formError, setFormError]: any = useState(null);
+  const [active, setActive] = useState<string>('Profile');
+  const [isEmployed, setIsEmployed] = useState(false);
+  const { data: alumni, mutate } = userHooks();
 
-  const menuList = ['Profile', 'Security', 'About']
+  const menuList = ['Profile', 'Security', 'About'];
 
-  const onClick = (e: React.FormEvent<HTMLButtonElement>) => {
-    const value = (e.target as HTMLElement).innerText
-    setActive(value)
-  }
+  const onClick = (e: React.FormEvent<HTMLButtonElement>) =>
+  {
+    const value = (e.target as HTMLElement).innerText;
+    setActive(value);
+  };
 
-  const modalMenu = menuList.map((menu: string, index: number) => {
+  const modalMenu = menuList.map((menu: string, index: number) =>
+  {
     return (
       <button
         key={index}
@@ -42,11 +46,13 @@ const AlumniSettings: FC<Props> = (props): JSX.Element => {
       >
         {menu}
       </button>
-    )
-  })
+    );
+  });
 
-  const activeComponent = (tab: string) => {
-    switch (tab) {
+  const activeComponent = (tab: string) =>
+  {
+    switch (tab)
+    {
       case 'Profile': {
         const {
           register,
@@ -60,10 +66,12 @@ const AlumniSettings: FC<Props> = (props): JSX.Element => {
             email: alumni?.email,
             contact_number: alumni?.contact_number
           }
-        })
+        });
 
-        const handleUpdateProfile = async (data: Profile): Promise<void> => {
-          try {
+        const handleUpdateProfile = async (data: Profile): Promise<void> =>
+        {
+          try
+          {
             const payload = {
               id: alumni?.id,
               name: data?.name,
@@ -72,57 +80,67 @@ const AlumniSettings: FC<Props> = (props): JSX.Element => {
               id_number: alumni?.id_number,
               birth_date: alumni?.birth_date,
               employment_status_id: alumni?.employment_status_id
-            }
+            };
 
-            const response = await axios.put('/api/user', payload)
+            const response = await axios.put('/api/user', payload);
 
-            if (response.status === 200) {
-              mutate()
-              toast.success('Successfully Updated!')
+            if (response.status === 200)
+            {
+              mutate();
+              toast.success('Successfully Updated!');
             }
-          } catch (error: any) {
-            if (error?.response?.status !== 422) throw error
-            toast.error(error?.response?.data?.message)
+          } catch (error: any)
+          {
+            if (error?.response?.status !== 422) throw error;
+            toast.error(error?.response?.data?.message);
           }
-        }
+        };
 
-        const updateAvatar = async (e: ChangeEvent<HTMLInputElement | null>): Promise<void> => {
-          try {
-            if (!e.target.files) return
+        const updateAvatar = async (e: ChangeEvent<HTMLInputElement | null>): Promise<void> =>
+        {
+          try
+          {
+            if (!e.target.files) return;
 
-            const files = e.target.files[0]
-            const formData = new FormData()
-            formData.append('avatar', files)
-            formData.append('_method', 'POST')
+            const files = e.target.files[0];
+            const formData = new FormData();
+            formData.append('avatar', files);
+            formData.append('_method', 'POST');
 
             const response = await axios.post('/api/user/user-avatar', formData, {
               headers: {
                 'Content-Type': 'multipart/form-data'
               }
-            })
+            });
 
-            if (response.status === 204) {
-              mutate()
-              toast.success('Successfully Updated!')
+            if (response.status === 204)
+            {
+              mutate();
+              toast.success('Successfully Updated!');
             }
-          } catch (error: any) {
-            if (error?.response?.status !== 422) throw error
-            toast.error(error?.response?.data?.message)
+          } catch (error: any)
+          {
+            if (error?.response?.status !== 422) throw error;
+            toast.error(error?.response?.data?.message);
           }
-        }
+        };
 
-        const removeAvatar = async (): Promise<void> => {
-          try {
-            const response = await axios.delete('/api/user/user-avatar')
-            if (response.status === 204) {
-              mutate()
-              toast.success('Successfully Deleted!')
+        const removeAvatar = async (): Promise<void> =>
+        {
+          try
+          {
+            const response = await axios.delete('/api/user/user-avatar');
+            if (response.status === 204)
+            {
+              mutate();
+              toast.success('Successfully Deleted!');
             }
-          } catch (error: any) {
-            if (error?.response?.status !== 422) throw error
-            toast.error(error?.response?.data?.message)
+          } catch (error: any)
+          {
+            if (error?.response?.status !== 422) throw error;
+            toast.error(error?.response?.data?.message);
           }
-        }
+        };
 
         return (
           <>
@@ -225,7 +243,7 @@ const AlumniSettings: FC<Props> = (props): JSX.Element => {
               </button>
             </form>
           </>
-        )
+        );
       }
 
       case 'Security': {
@@ -237,34 +255,38 @@ const AlumniSettings: FC<Props> = (props): JSX.Element => {
         } = useForm<Security>({
           mode: 'onTouched',
           resolver: yupResolver(SecurityFormSchema)
-        })
+        });
 
         // P.S.: This will handle Update the Security Password of the User
-        const handleUpdateSecurity = async (data: Security): Promise<void> => {
-          try {
+        const handleUpdateSecurity = async (data: Security): Promise<void> =>
+        {
+          try
+          {
             const payload = {
               currentPassword: data?.current_password,
               newPassword: data?.new_password,
               newConfirmedPassword: data?.password_confirmation
-            }
+            };
 
-            const response = await axios.put('/api/user/change-password', payload)
+            const response = await axios.put('/api/user/change-password', payload);
 
-            if (response?.status === 204) {
+            if (response?.status === 204)
+            {
               reset({
                 current_password: '',
                 new_password: '',
                 password_confirmation: ''
-              })
-              toast.success('Successfully Updated!')
-              setFormError(null)
+              });
+              toast.success('Successfully Updated!');
+              setFormError(null);
             }
-          } catch (error: any) {
-            if (error?.response?.status !== 422) throw error
-            setFormError(Object.values(error?.response?.data?.message).flat())
-            toast.error(error?.response?.data?.message)
+          } catch (error: any)
+          {
+            if (error?.response?.status !== 422) throw error;
+            setFormError(Object.values(error?.response?.data?.message).flat());
+            toast.error(error?.response?.data?.message);
           }
-        }
+        };
 
         return (
           <form className="flex flex-col gap-9" onSubmit={handleSubmit(handleUpdateSecurity)}>
@@ -339,7 +361,7 @@ const AlumniSettings: FC<Props> = (props): JSX.Element => {
               {isSubmitting ? <Spinner className="h-5 w-5" /> : 'Save Changes'}
             </button>
           </form>
-        )
+        );
       }
 
       case 'About': {
@@ -355,10 +377,12 @@ const AlumniSettings: FC<Props> = (props): JSX.Element => {
             birth_date: alumni?.birth_date,
             employment_status_id: alumni?.employment_status_id
           }
-        })
+        });
 
-        const handleUpdateAbout = async (data: About): Promise<void> => {
-          try {
+        const handleUpdateAbout = async (data: About): Promise<void> =>
+        {
+          try
+          {
             const payload = {
               id: alumni?.id,
               name: alumni?.name,
@@ -367,18 +391,20 @@ const AlumniSettings: FC<Props> = (props): JSX.Element => {
               id_number: data?.id_number,
               birth_date: data?.birth_date,
               employment_status_id: data?.employment_status_id
-            }
+            };
 
-            const response = await axios.put('/api/user', payload)
+            const response = await axios.put('/api/user', payload);
 
-            if (response.status === 200) {
-              mutate()
-              toast.success('Successfully Updated!')
+            if (response.status === 200)
+            {
+              mutate();
+              toast.success('Successfully Updated!');
             }
-          } catch (error) {
-            toast.error(`${error}`)
+          } catch (error)
+          {
+            toast.error(`${error}`);
           }
-        }
+        };
 
         const employmentStatus = [
           {
@@ -393,7 +419,7 @@ const AlumniSettings: FC<Props> = (props): JSX.Element => {
             id: 3,
             name: 'Unemployed'
           }
-        ]
+        ];
 
         return (
           <form className="flex flex-col gap-9" onSubmit={handleSubmit(handleUpdateAbout)}>
@@ -410,6 +436,18 @@ const AlumniSettings: FC<Props> = (props): JSX.Element => {
                   disabled={isSubmitting}
                   {...register('id_number')}
                   placeholder="00000000000"
+                />
+              </div>
+              <div>
+                <label htmlFor="course" className="form-label float-left">
+                  Course
+                </label>
+                <input
+                  type="text"
+                  id="course"
+                  defaultValue={alumni?.course ?? '---'}
+                  className="form-control"
+                  disabled={true}
                 />
               </div>
               <div>
@@ -439,9 +477,16 @@ const AlumniSettings: FC<Props> = (props): JSX.Element => {
                   disabled={isSubmitting}
                   {...register('employment_status_id')}
                   defaultValue={alumni?.employment_status_id}
+                  onClick={(e: any) =>
+                  {
+                    const value = e.target.value;
+
+                    if (value === '1') return setIsEmployed(true);
+                    setIsEmployed(false);
+                  }}
                 >
                   {employmentStatus.map(({ id, name }) => (
-                    <option key={id} value={id} selected={alumni?.employment_status_id === id}>
+                    <option key={id} value={id}>
                       {name}
                     </option>
                   ))}
@@ -451,18 +496,70 @@ const AlumniSettings: FC<Props> = (props): JSX.Element => {
                 )}
               </div>
             </div>
+            {isEmployed && (
+              <div className="flex flex-col gap-3">
+                <div>
+                  <label htmlFor="work_place" className="form-label float-left">
+                    Work Place
+                  </label>
+                  <input
+                    required
+                    type="text"
+                    id="work_place" 
+                    className="form-control"
+                    disabled={isSubmitting}
+                  />
+                </div>
+                <div>
+                  <label htmlFor="company_name" className="form-label float-left">
+                    Company Name
+                  </label>
+                  <input
+                    required
+                    type="text"
+                    id="company_name" 
+                    className="form-control"
+                    disabled={isSubmitting}
+                  />
+                </div>
+                <div>
+                  <label htmlFor="position" className="form-label float-left">
+                    Position
+                  </label>
+                  <input
+                    required
+                    type="text"
+                    id="position" 
+                    className="form-control"
+                    disabled={isSubmitting}
+                  />
+                </div>
+                <div>
+                  <label htmlFor="work_id" className="form-label float-left">
+                    Upload Work ID
+                  </label>
+                  <input
+                    required
+                    type="file"
+                    id="work_id" 
+                    className="form-control"
+                    disabled={isSubmitting}
+                  />
+                </div>
+              </div>
+            )}
             <button type="submit" className="form-submit mt-8" disabled={isSubmitting}>
               {isSubmitting ? <Spinner className="h-5 w-5" /> : 'Save Changes'}
             </button>
           </form>
-        )
+        );
       }
 
       default: {
-        return <h1 className="text-px-18 text-rose-600">404 Error!</h1>
+        return <h1 className="text-px-18 text-rose-600">404 Error!</h1>;
       }
     }
-  }
+  };
 
   return (
     <DialogBox
@@ -475,7 +572,7 @@ const AlumniSettings: FC<Props> = (props): JSX.Element => {
     >
       {activeComponent(active)}
     </DialogBox>
-  )
-}
+  );
+};
 
-export default AlumniSettings
+export default AlumniSettings;

--- a/client/src/components/molecules/AlumniSettings/types.ts
+++ b/client/src/components/molecules/AlumniSettings/types.ts
@@ -12,6 +12,7 @@ export type Security = {
 
 export type About = {
   id_number: string | undefined | null
+  course: string | undefined | null
   birth_date: string
   employment_status_id: number
 }

--- a/client/src/components/molecules/AuthForm/index.tsx
+++ b/client/src/components/molecules/AuthForm/index.tsx
@@ -1,36 +1,38 @@
-import Link from 'next/link'
-import React, { FC, useState } from 'react'
-import { EyeOff, Eye } from 'react-feather'
-import ReactDatePicker from 'react-datepicker'
-import { useForm, Controller } from 'react-hook-form'
-import { yupResolver } from '@hookform/resolvers/yup'
+import Link from 'next/link';
+import React, { FC, useState } from 'react';
+import { EyeOff, Eye } from 'react-feather';
+import ReactDatePicker from 'react-datepicker';
+import { useForm, Controller } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
 
-import useAxiosError from '~/hooks/axiosError'
-import { Spinner } from '~/shared/icons/SpinnerIcon'
-import { SignInFormSchema, SignUpFormSchema } from '~/shared/validation'
-import { AxiosResponseError, User } from '~/shared/types'
+import useAxiosError from '~/hooks/axiosError';
+import { Spinner } from '~/shared/icons/SpinnerIcon';
+import { SignInFormSchema, SignUpFormSchema } from '~/shared/validation';
+import { AxiosResponseError, User } from '~/shared/types';
 
 type Props = {
-  type?: string | 'alumni'
-  isLogin?: boolean | false
+  type?: string | 'alumni';
+  isLogin?: boolean | false;
   actions: {
-    handleAuthSubmit: (data: User) => Promise<void>
-  }
+    handleAuthSubmit: (data: User) => Promise<void>;
+  };
   axiosErrors: {
-    error: AxiosResponseError
-    isError: boolean
-  }
-}
+    error: AxiosResponseError;
+    isError: boolean;
+  };
+};
 
-const AuthForm: FC<Props> = (props): JSX.Element => {
-  const [showPass, setShowPass] = useState(false)
+const AuthForm: FC<Props> = (props): JSX.Element =>
+{
+  const [showPass, setShowPass] = useState(false);
+  const [isEmployed, setIsEmployed] = useState(false);
 
   const {
     type,
     isLogin,
     actions: { handleAuthSubmit },
     axiosErrors: { isError, error }
-  } = props
+  } = props;
 
   const {
     register,
@@ -41,11 +43,11 @@ const AuthForm: FC<Props> = (props): JSX.Element => {
   } = useForm<User>({
     mode: 'onTouched',
     resolver: yupResolver(isLogin ? SignInFormSchema : SignUpFormSchema)
-  })
+  });
 
-  useAxiosError(isError, error, setError)
+  useAxiosError(isError, error, setError);
 
-  const handleShowPasswordToggle = (): void => setShowPass(!showPass)
+  const handleShowPasswordToggle = (): void => setShowPass(!showPass);
 
   return (
     <form onSubmit={handleSubmit(handleAuthSubmit)}>
@@ -86,6 +88,25 @@ const AuthForm: FC<Props> = (props): JSX.Element => {
               </select>
             </div>
             <div className="col-span-12">
+              <label className="block text-sm font-medium">
+                <small className="text-rose-600">*</small> Course
+              </label>
+              <select
+                disabled={isSubmitting}
+                {...register('course')}
+                className={`
+                  block w-full rounded-sm border-[3px] border-[#4497ee] py-0.5 text-slate-900 outline-none 
+                  focus:border-[#3b83d1] focus:ring-0
+                `}
+              >
+                <option value={1}>BSIT</option>
+                <option value={2}>BSED</option>
+                <option value={3}>BEED</option>
+                <option value={4}>BPED</option>
+                <option value={5}>BSBA</option>
+              </select>
+            </div>
+            <div className="col-span-12">
               <label htmlFor="name" className="block text-sm font-medium">
                 <small className="text-rose-600">*</small> Name
               </label>
@@ -95,10 +116,9 @@ const AuthForm: FC<Props> = (props): JSX.Element => {
                 {...register('name')}
                 className={`
                   block w-full rounded-sm border-[3px] py-0.5 text-slate-900 outline-none focus:ring-0
-                  ${
-                    errors?.name
-                      ? 'border-rose-500 bg-rose-50 focus:border-rose-500'
-                      : 'border-[#4497ee] bg-white focus:border-[#3b83d1]'
+                  ${errors?.name
+                    ? 'border-rose-500 bg-rose-50 focus:border-rose-500'
+                    : 'border-[#4497ee] bg-white focus:border-[#3b83d1]'
                   }
                 `}
               />
@@ -117,10 +137,9 @@ const AuthForm: FC<Props> = (props): JSX.Element => {
             {...register('email')}
             className={`
               block w-full rounded-sm border-[3px] py-0.5 text-slate-900 outline-none focus:ring-0
-              ${
-                errors?.email
-                  ? 'border-rose-500 bg-rose-50 focus:border-rose-500'
-                  : 'border-[#4497ee] bg-white focus:border-[#3b83d1]'
+              ${errors?.email
+                ? 'border-rose-500 bg-rose-50 focus:border-rose-500'
+                : 'border-[#4497ee] bg-white focus:border-[#3b83d1]'
               }
             `}
           />
@@ -142,10 +161,9 @@ const AuthForm: FC<Props> = (props): JSX.Element => {
                     onChange={(date: Date) => field.onChange(date)}
                     className={`
                       block w-full rounded-sm border-[3px] py-0.5 text-slate-900 outline-none focus:ring-0
-                      ${
-                        errors?.birth_date
-                          ? 'border-rose-500 bg-rose-50 focus:border-rose-500'
-                          : 'border-[#4497ee] bg-white focus:border-[#3b83d1]'
+                      ${errors?.birth_date
+                        ? 'border-rose-500 bg-rose-50 focus:border-rose-500'
+                        : 'border-[#4497ee] bg-white focus:border-[#3b83d1]'
                       }
                     `}
                     disabled={isSubmitting}
@@ -166,10 +184,9 @@ const AuthForm: FC<Props> = (props): JSX.Element => {
                 {...register('contact_number')}
                 className={`
                   block w-full rounded-sm border-[3px] py-0.5 text-slate-900 outline-none focus:ring-0
-                  ${
-                    errors?.contact_number
-                      ? 'border-rose-500 bg-rose-50 focus:border-rose-500'
-                      : 'border-[#4497ee] bg-white focus:border-[#3b83d1]'
+                  ${errors?.contact_number
+                    ? 'border-rose-500 bg-rose-50 focus:border-rose-500'
+                    : 'border-[#4497ee] bg-white focus:border-[#3b83d1]'
                   }
                 `}
               />
@@ -182,22 +199,116 @@ const AuthForm: FC<Props> = (props): JSX.Element => {
                 <small className="text-rose-600">*</small> Employment Status
               </label>
               <select
+                onClick={(e: any) =>
+                {
+                  const value = e.target.value;
+
+                  if (value === '2') return setIsEmployed(true);
+                  setIsEmployed(false);
+                }}
                 disabled={isSubmitting}
                 {...register('employment_status')}
                 className={`
                   block w-full rounded-sm border-[3px] py-0.5 text-slate-900 outline-none focus:ring-0
-                  ${
-                    errors?.employment_status
-                      ? 'border-rose-500 bg-rose-50 focus:border-rose-500'
-                      : 'border-[#4497ee] bg-white focus:border-[#3b83d1]'
+                  ${errors?.employment_status
+                    ? 'border-rose-500 bg-rose-50 focus:border-rose-500'
+                    : 'border-[#4497ee] bg-white focus:border-[#3b83d1]'
                   }
                 `}
               >
-                <option value={1}>Unemployed</option>
-                <option value={2}>Employed</option>
-                <option value={3}>Self-Employed</option>
+                <option value={1} >Unemployed</option>
+                <option value={2} >Employed</option>
+                <option value={3} >Self-Employed</option>
               </select>
             </div>
+            {isEmployed && (
+              <>
+                <div className="col-span-12">
+                  <label className="block text-sm font-medium">
+                    <small className="text-rose-600">*</small> Work Place
+                  </label>
+                  <input
+                    required
+                    type="text"
+                    disabled={isSubmitting}
+                    {...register('work_place')}
+                    className={`
+                block w-full rounded-sm border-[3px] py-0.5 text-slate-900 outline-none focus:ring-0
+                ${errors?.work_place
+                        ? 'border-rose-500 bg-rose-50 focus:border-rose-500'
+                        : 'border-[#4497ee] bg-white focus:border-[#3b83d1]'
+                      }
+              `}
+                  />
+                  {errors?.work_place && (
+                    <span className="error">{`${errors?.work_place?.message}`}</span>
+                  )}
+                </div>
+                <div className="col-span-12">
+                  <label className="block text-sm font-medium">
+                    <small className="text-rose-600">*</small> Company Name
+                  </label>
+                  <input
+                    required
+                    type="text"
+                    disabled={isSubmitting}
+                    {...register('company_name')}
+                    className={`
+                  block w-full rounded-sm border-[3px] py-0.5 text-slate-900 outline-none focus:ring-0
+                  ${errors?.company_name
+                        ? 'border-rose-500 bg-rose-50 focus:border-rose-500'
+                        : 'border-[#4497ee] bg-white focus:border-[#3b83d1]'
+                      }
+                `}
+                  />
+                  {errors?.company_name && (
+                    <span className="error">{`${errors?.company_name?.message}`}</span>
+                  )}
+                </div>
+                <div className="col-span-12">
+                  <label className="block text-sm font-medium">
+                    <small className="text-rose-600">*</small> Position
+                  </label>
+                  <input
+                    required
+                    type="text"
+                    disabled={isSubmitting}
+                    {...register('position')}
+                    className={`
+                  block w-full rounded-sm border-[3px] py-0.5 text-slate-900 outline-none focus:ring-0
+                  ${errors?.position
+                        ? 'border-rose-500 bg-rose-50 focus:border-rose-500'
+                        : 'border-[#4497ee] bg-white focus:border-[#3b83d1]'
+                      }
+                `}
+                  />
+                  {errors?.position && (
+                    <span className="error">{`${errors?.position?.message}`}</span>
+                  )}
+                </div>
+                <div className="col-span-12">
+                  <label className="block text-sm font-medium">
+                    <small className="text-rose-600">*</small> Upload Work ID
+                  </label>
+                  <input
+                    required
+                    type="file"
+                    disabled={isSubmitting}
+                    {...register('work_id')}
+                    className={`
+                  block w-full rounded-sm border-[3px] py-0.5 text-slate-900 outline-none focus:ring-0
+                  ${errors?.work_id
+                        ? 'border-rose-500 bg-rose-50 focus:border-rose-500'
+                        : 'border-[#4497ee] bg-white focus:border-[#3b83d1]'
+                      }
+                `}
+                  />
+                  {errors?.work_id && (
+                    <span className="error">{`${errors?.work_id?.message}`}</span>
+                  )}
+                </div>
+              </>
+            )}
           </>
         )}
         <div className="col-span-12">
@@ -211,11 +322,10 @@ const AuthForm: FC<Props> = (props): JSX.Element => {
               {...register('password')}
               className={`
               block w-full rounded-sm border-[3px] py-0.5 text-slate-900 outline-none focus:ring-0
-              ${
-                errors?.password
+              ${errors?.password
                   ? 'border-rose-500 bg-rose-50 focus:border-rose-500'
                   : 'border-[#4497ee] bg-white focus:border-[#3b83d1]'
-              }
+                }
             `}
             />
             <button
@@ -257,10 +367,9 @@ const AuthForm: FC<Props> = (props): JSX.Element => {
               autoComplete="password"
               className={`
                 block w-full rounded-sm border-[3px] py-0.5 text-slate-900 outline-none focus:ring-0
-                ${
-                  errors?.password_confirmation
-                    ? 'border-rose-500 bg-rose-50 focus:border-rose-500'
-                    : 'border-[#4497ee] bg-white focus:border-[#3b83d1]'
+                ${errors?.password_confirmation
+                  ? 'border-rose-500 bg-rose-50 focus:border-rose-500'
+                  : 'border-[#4497ee] bg-white focus:border-[#3b83d1]'
                 }
               `}
             />
@@ -301,7 +410,7 @@ const AuthForm: FC<Props> = (props): JSX.Element => {
         </button>
       </div>
     </form>
-  )
-}
+  );
+};
 
-export default AuthForm
+export default AuthForm;

--- a/client/src/pages/admin/dashboard.tsx
+++ b/client/src/pages/admin/dashboard.tsx
@@ -84,6 +84,8 @@ const Dashboard: NextPage = (): JSX.Element => {
     ["BEED - Unemployed", 3],
     ["BPED - Employed", 9],
     ["BPED - Unemployed", 6],
+    ["BSBA - Employed", 12],
+    ["BSBA - Unemployed", 11],
   ]; 
 
   const pieChartOptions = {
@@ -100,6 +102,8 @@ const Dashboard: NextPage = (): JSX.Element => {
       5: { color: "#002147" }, 
       6: { color: "#2E8BC0" }, 
       7: { color: "#002147" }, 
+      8: { color: "#2E8BC0" }, 
+      9: { color: "#002147" }, 
     },
   };
 
@@ -205,21 +209,21 @@ const Dashboard: NextPage = (): JSX.Element => {
               />
             </div>
             <div className="w-full p-5 text-start">
-              <ul className="flex flex-col gap-3">
+              <div className="flex flex-col">
                 {pieChartData.map((data: any, index: number)=>{
                   if (index === 0) return null
 
                   return (
-                    <li className="flex justify-start items-center gap-1" key={index}>
+                    <div className={`flex justify-start items-center gap-1 ${index % 2 === 0 || "mt-6"}`} key={index}>
                       <div className={`${index % 2 === 0 ? 'bg-[#002147]' : 'bg-[#2E8BC0]'} rounded-full !h-[10px] !w-[10px]`}></div>
                       <div className="w-full flex justify-between items-center">
                         <div>{data[0]}</div>
                         <div className="text-md font-medium">{data[1]}</div>
                       </div> 
-                    </li>
+                    </div>
                   )
                 })}
-              </ul>
+              </div>
             </div>
           </div>
         </Card>

--- a/client/src/pages/admin/employment-status.tsx
+++ b/client/src/pages/admin/employment-status.tsx
@@ -176,7 +176,7 @@ const EmploymentStatus: NextPage = (): JSX.Element => {
                         { header: "Work Place", value: work_place },
                         { header: "Company Name", value: company_name },
                         { header: "Position", value: position },
-                        { header: "Employment ID", value: (
+                        { header: "Employment ID", value: employment_id && (
                           <a href={employment_id} target="_new">
                             <img 
                               src={employment_id} 

--- a/client/src/shared/interfaces/index.ts
+++ b/client/src/shared/interfaces/index.ts
@@ -15,6 +15,11 @@ export interface IAlumniData {
   id_number: string
   name: string
   email: string
+  course: string
+  work_place: string
+  company_name: string
+  position: string
+  work_id: string
   birth_date: string
   contact_number: string
   is_verified: number | boolean

--- a/client/src/shared/types/index.ts
+++ b/client/src/shared/types/index.ts
@@ -1,11 +1,16 @@
 export type User = {
   id_number?: string
   batch: string
+  course: string
   name: string
   email: string
   birth_date: string
   contact_number: string
   employment_status: string
+  work_place: string
+  company_name: string
+  position: string
+  work_id: any
   role?: number
   is_verified?: boolean | number
   password: string

--- a/client/src/shared/validation/index.ts
+++ b/client/src/shared/validation/index.ts
@@ -20,6 +20,11 @@ export const SignUpFormSchema = Yup.object().shape({
     .max(11),
   employment_status: Yup.string().required().label('Employment Status'),
   batch: Yup.string().required().label('Batch'),
+  course: Yup.string().required().label('Course'),
+  work_place: Yup.string().label('Work Place'),
+  company_name: Yup.string().label('Company Name'),
+  position: Yup.string().label('Position'),
+  work_id: Yup.mixed(),
   password: Yup.string()
     .required('Password is required')
     .min(4, 'Password length should be at least 4 characters')
@@ -55,6 +60,11 @@ export const SecurityFormSchema = Yup.object().shape({
 
 export const AboutFormSchema = Yup.object().shape({
   id_number: Yup.string(),
+  course: Yup.string(),
+  work_place: Yup.string(),
+  company_name: Yup.string(),
+  position: Yup.string(),
+  work_id: Yup.mixed(),
   birth_date: Yup.string().required('Birth date is required'),
   employment_status_id: Yup.number().required('Employment Status is required')
 })


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203127372768065/1203633086238471/f

## Definition of Done
- [x] There's a course filed in the registration
- [x] There are workplace, company name, position, and work id fields when employed is selected on the registration page.
- [x] There are workplace, company name, position, and work id fields when employed is selected on the user settings about tab.

## Pre-condition
-  http://localhost:3000/register

## Expected Output
- When employed is selected in the employment status dropdown, it should show the fields for the workplace, company name, position, and work id.
- Also in user settings at the about tab. When employed is selected in the employment status dropdown, it should show the fields for the workplace, company name, position, and work id.

## Screenshots/Recordings
![image](https://user-images.githubusercontent.com/104751512/210178143-93f0bb54-c18a-495d-98ff-dc0578759aa7.png)
![image](https://user-images.githubusercontent.com/104751512/210178199-98d65af0-0335-49ca-a072-4aeede8e9dbe.png)

