### PR TITLE
[Bugtask] Filter only approved alumni in API

### DIFF
--- a/api/app/Http/Controllers/DashboardController.php
+++ b/api/app/Http/Controllers/DashboardController.php
@@ -2,17 +2,17 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Resources\BatchEmploymentStatusResource;
 use App\Models\Post;
 use App\Models\User;
+use App\Enums\ApplicationStatusEnum;
 
 class DashboardController extends Controller
 {
     public function index()
     {
-        $employed = User::applicants()->filterBatch(request('batch'))->employed()->count();
-        $unemployed = User::applicants()->filterBatch(request('batch'))->unEmployed()->count();
-        $selfEmployed = User::applicants()->filterBatch(request('batch'))->selfEmployed()->count();
+        $employed = User::applicants()->where('is_verified', ApplicationStatusEnum::APPROVED)->filterBatch(request('batch'))->employed()->count();
+        $unemployed = User::applicants()->where('is_verified', ApplicationStatusEnum::APPROVED)->filterBatch(request('batch'))->unEmployed()->count();
+        $selfEmployed = User::applicants()->where('is_verified', ApplicationStatusEnum::APPROVED)->filterBatch(request('batch'))->selfEmployed()->count();
 
         return response()->json([
             'batch' => [


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203127372768065/1203629268729131/f

## Definition of Done
- [x] The bar chart is not reading the pending alumni employment status

## Pre-condition
- http://localhost:3000/admin/dashboard

## Expected Output
- When there are 2 alumni 1 is approved and 1 is pending, the bar chart should not read the pending alumni employment status

## Screenshots/Recordings
![image](https://user-images.githubusercontent.com/104751512/210179389-cec7bcda-cd02-4cc9-aa7b-68992bae0491.png)
![image](https://user-images.githubusercontent.com/104751512/210179392-226b7f62-dd97-475b-82a3-e406e8628459.png)
