### PR TITLE
[FE] Integrate GET total count of graduated separated by courses in Pie Chart

### DIFF
--- a/client/src/hooks/admin/adminHooks.ts
+++ b/client/src/hooks/admin/adminHooks.ts
@@ -157,9 +157,10 @@ const adminHooks = () => {
   const getDashboardData = async (id: number) => {
     try {
       const response = await axios.get(`/api/admin/dashboard?batch=${id}`)
+      const responseList = await axios.get('/api/course-count')
       setFetchStatus(setData(fetchStatus, { isLoading: false }))
-
-      return response.data
+      
+      return {...response.data, listOfGraduated: responseList.data}
     } catch (err: any) {
       return setErrorMessage(err)
     }

--- a/client/src/pages/admin/dashboard.tsx
+++ b/client/src/pages/admin/dashboard.tsx
@@ -34,22 +34,27 @@ const years = [
 
 const Dashboard: NextPage = (): JSX.Element => {
   const { getDashboardData } = adminHooks();
-  const [dashboardData, setDashboardData] = useState<Dashboard | null>(null);
+  const [dashboardData, setDashboardData] = useState<any>(null);
   const [selectedIndex, setSelectedIndex] = useState<number>(years?.length - 1);
   const [selected, setSelected] = useState<string>(years[selectedIndex]);
 
   const { innerWidth } = useWindowDimensions() || {};
   const mobileView = innerWidth <= 1000;
 
-  const { batch, total_posts, total_users } = dashboardData || {};
-  const { employed, selfEmployed, unemployed } = batch || {};
+  const { batch, total_posts, total_users, listOfGraduated } = dashboardData || {};
+  const { employed, selfEmployed, unemployed } = batch || {}; 
+  const bsit = listOfGraduated && listOfGraduated[0]?.BSIT
+  const bsed = listOfGraduated && listOfGraduated[1]?.BSED
+  const beed = listOfGraduated && listOfGraduated[2]?.BEED
+  const bped = listOfGraduated && listOfGraduated[3]?.BPED
+  const bsba = listOfGraduated && listOfGraduated[4]?.BSBA
 
   useEffect(() => {
     getDashboardData(selectedIndex + 1).then((res) => {
       setDashboardData(res);
     });
   }, [selectedIndex]);
-
+  
   const data = [
     [
       "Employment Status",
@@ -76,35 +81,37 @@ const Dashboard: NextPage = (): JSX.Element => {
 
   const pieChartData = [
     ["Task", "Hours per Day"],
-    ["BSIT - Employed", 12],
-    ["BSIT - Unemployed", 1],
-    ["BSED - Employed", 3],
-    ["BSED - Unemployed", 2],
-    ["BEED - Employed", 6],
-    ["BEED - Unemployed", 3],
-    ["BPED - Employed", 9],
-    ["BPED - Unemployed", 6],
-    ["BSBA - Employed", 12],
-    ["BSBA - Unemployed", 11],
+    ["BSIT - Employed", bsit?.employed],
+    ["BSIT - Unemployed", bsit?.unemployed],
+    ["BSED - Employed", bsed?.employed],
+    ["BSED - Unemployed", bsed?.unemployed],
+    ["BEED - Employed", beed?.employed],
+    ["BEED - Unemployed", beed?.unemployed],
+    ["BPED - Employed", bped?.employed],
+    ["BPED - Unemployed", bped?.unemployed],
+    ["BSBA - Employed", bsba?.employed],
+    ["BSBA - Unemployed", bsba?.unemployed],
   ]; 
+
+  const slices: any =  {
+    0: { color: "#ab00ff" }, 
+    1: { color: "#31004a" }, 
+    2: { color: "#a6754a" }, 
+    3: { color: "#582205" }, 
+    4: { color: "#ffcf40" }, 
+    5: { color: "#a67c00" }, 
+    6: { color: "#e50000" }, 
+    7: { color: "#820000" }, 
+    8: { color: "#283198" }, 
+    9: { color: "#0c136d" }, 
+  }
 
   const pieChartOptions = {
     legend: { position: "none" },
     backgroundColor: 'transparent',
     chartArea: { 'width': mobileView ? "100%" : '' },
     is3D: true,
-    slices: {
-      0: { color: "#2E8BC0" }, 
-      1: { color: "#002147" }, 
-      2: { color: "#2E8BC0" }, 
-      3: { color: "#002147" }, 
-      4: { color: "#2E8BC0" }, 
-      5: { color: "#002147" }, 
-      6: { color: "#2E8BC0" }, 
-      7: { color: "#002147" }, 
-      8: { color: "#2E8BC0" }, 
-      9: { color: "#002147" }, 
-    },
+    slices
   };
 
   const DashboardContent = () => {
@@ -210,12 +217,11 @@ const Dashboard: NextPage = (): JSX.Element => {
             </div>
             <div className="w-full p-5 text-start">
               <div className="flex flex-col">
-                {pieChartData.map((data: any, index: number)=>{
-                  if (index === 0) return null
-
+                {pieChartData.map((data: any, index: number)=>{ 
+                  if ( index === 0 ) return null
                   return (
                     <div className={`flex justify-start items-center gap-1 ${index % 2 === 0 || "mt-6"}`} key={index}>
-                      <div className={`${index % 2 === 0 ? 'bg-[#002147]' : 'bg-[#2E8BC0]'} rounded-full !h-[10px] !w-[10px]`}></div>
+                      <div className="rounded-full !h-[10px] !w-[10px]" style={{'backgroundColor': slices[index - 1]?.color}}></div>
                       <div className="w-full flex justify-between items-center">
                         <div>{data[0]}</div>
                         <div className="text-md font-medium">{data[1]}</div>


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203127372768065/1203629268729102/f

## Definition of Done
- [x] Admin can see the total list of Graduate in the Pie Chart
- [x] Light colors for employed alumni 
- [x] Dark colors for unemployed alumni 

## Pre-condition
- http://localhost:3000/admin/dashboard

## Expected Output
- The total count for employed and unemployed alumni should display in a Pie Chart

## Screenshots/Recordings
![image](https://user-images.githubusercontent.com/104751512/210617052-1cd8e6e8-b4b2-4034-bf50-d61868d85969.png)
